### PR TITLE
Add 'due' date as atom constant

### DIFF
--- a/grammars/todotxt.cson
+++ b/grammars/todotxt.cson
@@ -12,6 +12,10 @@
     'name': 'constant.language.todotxt.date'
   }
   {
+    'match': 'due:\\d{4}-\\d{2}-\\d{2}'
+    'name': 'constant.language.todotxt.due'
+  }
+  {
     'match': '\\@\\S*'
     'name': 'entity.name.tag.todotxt.context'
   }


### PR DESCRIPTION
The current todotxt syntax highlighting supports 't' which marks the start date of a task in todo.txt. This pull request adds 'due' date highlighting using the same format as 't'. 'due' is not officially included in the todo.txt language definition, but it is suggested as a possible extension (https://github.com/ginatrapani/todo.txt-cli/wiki/The-Todo.txt-Format#add-on-file-format-definitions) and used by todo.txt clients such as Simpletask (https://github.com/mpcjanssen/simpletask-android).
