### PR TITLE
Run todotxt:done command in a transaction

### DIFF
--- a/lib/language-todotxt.js
+++ b/lib/language-todotxt.js
@@ -72,10 +72,12 @@ export default {
       }
       let now = this.dateNow()
       line = `x ${now} ${line}`
-      te.moveToBeginningOfLine()
-      te.deleteToEndOfLine()
-      te.insertText(line)
-      te.moveToBeginningOfLine()
+      te.getBuffer().transact(() => {
+        te.moveToBeginningOfLine()
+        te.deleteToEndOfLine()
+        te.insertText(line)
+        te.moveToBeginningOfLine()
+      })
     }
   },
 

--- a/spec/done-command-spec.js
+++ b/spec/done-command-spec.js
@@ -119,4 +119,26 @@ describe("todo.txt done command", () => {
     expect(text).toEqual("x 2017-10-19 todotxt:done on a line that is already done +LanguageTodotxt");
   });
 
+  it("makes edits in a single transaction", () => {
+
+    const getCurrentLine = (te) => {
+      let pt = te.getCursorBufferPosition();
+      return te.lineTextForBufferRow(pt.row);
+    };
+
+    let te = atom.workspace.getActiveTextEditor();
+    te.moveDown(5);
+    let text = getCurrentLine(te);
+    expect(text).toEqual("(A) 2017-10-17 Implement the todotxt:done command +LanguageTodotxt");
+    atom.commands.dispatch(workspaceElement(), 'todotxt:done');
+    text = getCurrentLine(te);
+    let dt = new Date();
+    let now = `${dt.getFullYear()}-${(dt.getMonth() < 8) ? '0' : ''}${dt.getMonth() + 1}-${dt.getDate() < 10 ? '0' : ''}${dt.getDate()}`;
+    expect(text).toEqual(`x ${now} 2017-10-17 Implement the todotxt:done command +LanguageTodotxt pri:A`);
+
+    te.undo();
+    text = getCurrentLine(te);
+    expect(text).toEqual("(A) 2017-10-17 Implement the todotxt:done command +LanguageTodotxt");
+  });
+
 });


### PR DESCRIPTION
Currently, if you mark an item as done, then undo, you get a blank line.
You have to undo again to restore the original line. Running the editing
commands in a TextBuffer transaction will let them both be undone at the
same time.