### PR TITLE
Add Syntax highlight for done.txt files

### DIFF
--- a/grammars/todotxt.cson
+++ b/grammars/todotxt.cson
@@ -1,4 +1,5 @@
 'fileTypes': [
+  'done.txt',
   'todo.txt'
 ]
 'name': 'TodoTXT'


### PR DESCRIPTION
[plaintext-productivity.net](https://plaintext-productivity.net/1-05-accountability-todo-txt-and-done-txt.html) recommends to archive done tasks into a _done.txt_ file so I just add highlight support for theses files.