### PR TITLE
Fix "Failed to activate language-todotxt package"

### DIFF
--- a/lib/language-todotxt.js
+++ b/lib/language-todotxt.js
@@ -42,8 +42,7 @@ export default {
 
     const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
-    for (i in letters) {
-      let letter = letters[i]
+    for (let letter of letters) {
       let key = `todotxt:priority-${letter.toLowerCase()}`
       let value = () => { this.priority(letter) }
       commands[key] = value


### PR DESCRIPTION
For some reason, a `toEnd` method was monkey patched onto strings. This breaks iterating over them by index using `in`. Fortunately, we can just use `of` iteration.

Fixes #54 